### PR TITLE
THRED-4: Adds storybook support for Thread

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,10 @@
 {
   "name": "@shopkeep/thread",
-  "version": "0.0.7-alpha",
+  "version": "0.0.7",
   "exports": "./main.ts",
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --watch main.ts",
+    "test": "deno test --allow-read"
   },
   "license": "MIT",
   "imports": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopkeep/thread",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha",
   "exports": "./main.ts",
   "tasks": {
     "dev": "deno run --watch main.ts"

--- a/lib/thread.test.ts
+++ b/lib/thread.test.ts
@@ -85,6 +85,52 @@ describe("testing options", () => {
   });
 });
 
+describe("tests storybook files", () => {
+  const htmlInput =
+    `<Story name="Primary" args={{ cs: { backgroundColor: 'aqua', width: '50px', height: '50px' }, text: 'Hello, world!'}}/>`;
+  const htmlOutput =
+    `<Story name="Primary" args={{ style: "background-color: aqua; width: 50px; height: 50px;", text: 'Hello, world!'}}/>`;
+
+  it.only("works if file has .story file extension", () => {
+    const input = script + htmlInput + style;
+    const output = script + htmlOutput + style;
+
+    const result = thread(input, "Test.story.svelte", {
+      ...options,
+    });
+    expect(result).toEqual(output);
+  });
+
+  it("works if file has .stories file extension", () => {
+    const input = script + htmlInput + style;
+    const output = script + htmlOutput + style;
+
+    const result = thread(input, "Test.stories.svelte", {
+      ...options,
+    });
+    expect(result).toEqual(output);
+  });
+  it("works if file has multiple stories", () => {
+    const input = script + htmlInput + htmlInput + style;
+    const output = script + htmlOutput + htmlOutput + style;
+
+    const result = thread(input, "Test.story.svelte", {
+      ...options,
+    });
+    expect(result).toEqual(output);
+  });
+  it("works if user supplied fileIdentifier", () => {
+    const input = script + htmlInput + htmlInput + style;
+    const output = script + htmlOutput + htmlOutput + style;
+
+    const result = thread(input, "Test.story.svelte", {
+      ...options,
+      fileIdentifier: "thread",
+    });
+    expect(result).toEqual(output);
+  });
+});
+
 describe("parsing attributes", () => {
   it("converts a single attribute", () => {
     const htmlInput = `<Flexbox cs={{ gap: '10px' }}></Flexbox>`;

--- a/lib/thread.test.ts
+++ b/lib/thread.test.ts
@@ -91,7 +91,7 @@ describe("tests storybook files", () => {
   const htmlOutput =
     `<Story name="Primary" args={{ style: "background-color: aqua; width: 50px; height: 50px;", text: 'Hello, world!'}}/>`;
 
-  it.only("works if file has .story file extension", () => {
+  it("works if file has .story file extension", () => {
     const input = script + htmlInput + style;
     const output = script + htmlOutput + style;
 
@@ -119,11 +119,19 @@ describe("tests storybook files", () => {
     });
     expect(result).toEqual(output);
   });
-  it("works if user supplied fileIdentifier", () => {
+  it("does not parse if filename does not have fileIdentifier ", () => {
+    const input = script + htmlInput + htmlInput + style;
+    const result = thread(input, "Test.story.svelte", {
+      ...options,
+      fileIdentifier: "thread",
+    });
+    expect(result).toEqual(input);
+  });
+  it("does parse if filename does have fileIdentifier", () => {
     const input = script + htmlInput + htmlInput + style;
     const output = script + htmlOutput + htmlOutput + style;
 
-    const result = thread(input, "Test.story.svelte", {
+    const result = thread(input, "Test.thread.story.svelte", {
       ...options,
       fileIdentifier: "thread",
     });

--- a/lib/thread.test.ts
+++ b/lib/thread.test.ts
@@ -91,12 +91,14 @@ describe("tests storybook files", () => {
   const htmlOutput =
     `<Story name="Primary" args={{ style: "background-color: aqua; width: 50px; height: 50px;", text: 'Hello, world!'}}/>`;
 
+  const storybookOptions = { ...options, shouldIncludeStorybookFiles: true };
+
   it("works if file has .story file extension", () => {
     const input = script + htmlInput + style;
     const output = script + htmlOutput + style;
 
     const result = thread(input, "Test.story.svelte", {
-      ...options,
+      ...storybookOptions,
     });
     expect(result).toEqual(output);
   });
@@ -106,7 +108,7 @@ describe("tests storybook files", () => {
     const output = script + htmlOutput + style;
 
     const result = thread(input, "Test.stories.svelte", {
-      ...options,
+      ...storybookOptions,
     });
     expect(result).toEqual(output);
   });
@@ -115,14 +117,14 @@ describe("tests storybook files", () => {
     const output = script + htmlOutput + htmlOutput + style;
 
     const result = thread(input, "Test.story.svelte", {
-      ...options,
+      ...storybookOptions,
     });
     expect(result).toEqual(output);
   });
   it("does not parse if filename does not have fileIdentifier ", () => {
     const input = script + htmlInput + htmlInput + style;
     const result = thread(input, "Test.story.svelte", {
-      ...options,
+      ...storybookOptions,
       fileIdentifier: "thread",
     });
     expect(result).toEqual(input);
@@ -132,10 +134,19 @@ describe("tests storybook files", () => {
     const output = script + htmlOutput + htmlOutput + style;
 
     const result = thread(input, "Test.thread.story.svelte", {
-      ...options,
+      ...storybookOptions,
       fileIdentifier: "thread",
     });
     expect(result).toEqual(output);
+  });
+  it("does not parse if shouldIncludeStorybookOptions is not set", () => {
+    const input = script + htmlInput + htmlInput + style;
+
+    const result = thread(input, "Test.thread.story.svelte", {
+      ...options,
+      fileIdentifier: "thread",
+    });
+    expect(result).toEqual(input);
   });
 });
 

--- a/lib/thread.ts
+++ b/lib/thread.ts
@@ -87,13 +87,13 @@ function convertToSyleString(properties: Property[]): string {
           const leftValue = property.value.test.left.type === "Literal"
             ? property.value.test.left.raw
             : property.value.test.left.type === "Identifier"
-              ? property.value.test.left.name
-              : "";
+            ? property.value.test.left.name
+            : "";
           const rightValue = property.value.test.right.type === "Literal"
             ? property.value.test.right.raw
             : property.value.test.right.type === "Identifier"
-              ? property.value.test.right.name
-              : "";
+            ? property.value.test.right.name
+            : "";
           return acc +
             `${propertyName}: {${leftValue} ${property.value.test.operator} ${rightValue} ? '${property.value.consequent.value}' : '${property.value.alternate.value}'}; `;
         }
@@ -150,8 +150,9 @@ function parseStorybookNode(
     const filteredProperties = styleAttribute.value.properties.filter((
       property: Property | SpreadElement,
     ) => property.type === "Property");
-    const newStyleString = `style: "${convertToSyleString(filteredProperties)
-      }"`;
+    const newStyleString = `style: "${
+      convertToSyleString(filteredProperties)
+    }"`;
     return { newStyleString, styleAttribute };
   }
   return { newStyleString: "", styleAttribute: null };

--- a/lib/thread.ts
+++ b/lib/thread.ts
@@ -16,6 +16,8 @@ export type Options = {
   elementNames: string[];
 };
 
+type ExtendedProperty = Property & Partial<AST.BaseNode>
+
 /**
  * Converts a camelCase string to kebab-case.
  *
@@ -41,145 +43,153 @@ function parseTemplateLiteralValue(value: any): string | null {
   return `${pre}\{${variable}}${post}`;
 }
 
-function convertToSyleString(properties: (Property | SpreadElement)[]): string {
-  return properties.reduce((acc: string, property: Property | SpreadElement) => {
-    // TODO - this is also a mess
-    if (!("key" in property)) return acc;
-    if (!("name" in property.key)) return acc;
-
-    const propertyName = camelToKebabCase(property.key.name);
-
-    // Returns if the value is a variable - i.e. cs={{gap: gapAmount}}
-    if ("name" in property.value) {
-      return acc + `${propertyName}: {${property.value.name}}; `;
-    }
-
-    // Returns if the value is a string - i.e. cs={{gap: '10px'}}
-    if (("value" in property.value)) {
-      return acc + `${propertyName}: ${property.value.value}; `;
-    }
-
-    // Returns if the value is a template literal - i.e. cs={{gap: `${computedHeight}px` }}
-    if (property.value.type === "TemplateLiteral") {
-      return acc +
-        `${propertyName}: ${parseTemplateLiteralValue(property.value)}; `;
-    }
-
-    // Returns if the value is a ternary
-    if (
-      property.value.type === "ConditionalExpression" &&
-      property.value.consequent.type === "Literal" &&
-      property.value.alternate.type === "Literal"
-    ) {
-      // Returns if the value is a ternary - i.e. cs={{gap: isGap ? '10px' : '20px'}}
-      if (property.value.test.type === "Identifier") {
-        return acc +
-          `${propertyName}: {${property.value.test.name} ? '${property.value.consequent.value}' : '${property.value.alternate.value}'}; `;
-      }
-
-      // Returns if the value is a ternary - i.e. cs={{gap: isGap ? '10px' : '20px'}}
-      if (property.value.test.type === "BinaryExpression") {
-        const leftValue = property.value.test.left.type === "Literal"
-          ? property.value.test.left.raw
-          : property.value.test.left.type === "Identifier"
-            ? property.value.test.left.name
-            : "";
-        const rightValue = property.value.test.right.type === "Literal"
-          ? property.value.test.right.raw
-          : property.value.test.right.type === "Identifier"
-            ? property.value.test.right.name
-            : "";
-        return acc +
-          `${propertyName}: {${leftValue} ${property.value.test.operator} ${rightValue} ? '${property.value.consequent.value}' : '${property.value.alternate.value}'}; `;
-      }
-    }
-    // Fallback
-    return acc;
-  }, "");
-}
 
 // TODO - insert design system specific values to transition things like 1 to 4px etc
-// TODO - clean this up so values are more readable and consistent (more separate functions based off type?)
-function convertsCsPropToInlineStyles(
-  customStylingAttribute: AST.BaseElement["attributes"][number],
-): string | null {
-  // TODO - this is a mess
-  if (customStylingAttribute.type !== "Attribute") return null;
-  if (typeof customStylingAttribute.value === "boolean") return null;
-  if (Array.isArray(customStylingAttribute.value)) return null;
-  if (customStylingAttribute.value.expression.type !== "ObjectExpression") {
-    return null;
-  }
+function convertToSyleString(properties: Property[]): string {
+  const insideString = properties.reduce(
+    (acc: string, property: Property | SpreadElement) => {
+      // TODO - this is also a mess
+      if (!("key" in property)) return acc;
+      if (!("name" in property.key)) return acc;
 
-  const styleString = convertToSyleString(customStylingAttribute.value.expression.properties);
-  return `style="${styleString.trim()}"`;
+      const propertyName = camelToKebabCase(property.key.name);
+
+      // Returns if the value is a variable - i.e. cs={{gap: gapAmount}}
+      if ("name" in property.value) {
+        return acc + `${propertyName}: {${property.value.name}}; `;
+      }
+
+      // Returns if the value is a string - i.e. cs={{gap: '10px'}}
+      if (("value" in property.value)) {
+        return acc + `${propertyName}: ${property.value.value}; `;
+      }
+
+      // Returns if the value is a template literal - i.e. cs={{gap: `${computedHeight}px` }}
+      if (property.value.type === "TemplateLiteral") {
+        return acc +
+          `${propertyName}: ${parseTemplateLiteralValue(property.value)}; `;
+      }
+
+      // Returns if the value is a ternary
+      if (
+        property.value.type === "ConditionalExpression" &&
+        property.value.consequent.type === "Literal" &&
+        property.value.alternate.type === "Literal"
+      ) {
+        // Returns if the value is a ternary - i.e. cs={{gap: isGap ? '10px' : '20px'}}
+        if (property.value.test.type === "Identifier") {
+          return acc +
+            `${propertyName}: {${property.value.test.name} ? '${property.value.consequent.value}' : '${property.value.alternate.value}'}; `;
+        }
+
+        // Returns if the value is a ternary - i.e. cs={{gap: isGap ? '10px' : '20px'}}
+        if (property.value.test.type === "BinaryExpression") {
+          const leftValue = property.value.test.left.type === "Literal"
+            ? property.value.test.left.raw
+            : property.value.test.left.type === "Identifier"
+              ? property.value.test.left.name
+              : "";
+          const rightValue = property.value.test.right.type === "Literal"
+            ? property.value.test.right.raw
+            : property.value.test.right.type === "Identifier"
+              ? property.value.test.right.name
+              : "";
+          return acc +
+            `${propertyName}: {${leftValue} ${property.value.test.operator} ${rightValue} ? '${property.value.consequent.value}' : '${property.value.alternate.value}'}; `;
+        }
+      }
+      // Fallback
+      return acc;
+    },
+    "",
+  );
+  return insideString.trim();
 }
 
-function parseNodes(
+
+function findAttribute(attributes: AST.BaseElement["attributes"], searchParameter: string): AST.Attribute | undefined {
+  const attribute = attributes.find(
+    (attr: AST.BaseElement["attributes"][number]) =>
+      "name" in attr && attr.name === searchParameter,
+  );
+  if (!attribute || attribute.type !== "Attribute" || typeof attribute.value === 'boolean' || Array.isArray(attribute.value)) return undefined;
+  return attribute;
+}
+
+function findProperties(attribute: AST.BaseElement["attributes"][number]): ExtendedProperty[] | undefined {
+  if (!attribute || attribute.type !== "Attribute" || typeof attribute.value === 'boolean' || Array.isArray(attribute.value) ||
+    attribute.value.expression.type !== "ObjectExpression") return undefined;
+  return attribute.value.expression.properties.filter((property: ExtendedProperty | SpreadElement) => property.type === "Property");
+}
+
+function parseStorybookNode(node: AST.Component, options: Options): { newStyleString: string, styleAttribute: ExtendedProperty | null } {
+  const attribute = findAttribute(node.attributes, "args");
+  if (!attribute) return { newStyleString: '', styleAttribute: null };
+  const attributeProperties = findProperties(attribute);
+
+  const styleAttribute = attributeProperties?.find((att) => 'name' in att.key && att.key.name === options.attributeName);
+
+  if (styleAttribute && styleAttribute.value.type === 'ObjectExpression') {
+    const filteredProperties = styleAttribute.value.properties.filter((property: Property | SpreadElement) => property.type === "Property");
+    const newStyleString = `style: "${convertToSyleString(filteredProperties)}"`;
+    return { newStyleString, styleAttribute };
+  }
+  return { newStyleString: '', styleAttribute: null };
+}
+
+function parseNode(node: AST.Component, options: Options): { newStyleString: string, styleAttribute: AST.Attribute | null } {
+  const styleAttribute = findAttribute(node.attributes, options.attributeName);
+  if (!styleAttribute) return { newStyleString: '', styleAttribute: null };
+  const styleProperties = findProperties(styleAttribute);
+
+  if (styleProperties) {
+    const newStyleString = `style="${convertToSyleString(styleProperties)}"`;
+    return { newStyleString, styleAttribute };
+  }
+  return { newStyleString: '', styleAttribute };
+}
+
+function replaceFileContents(
   content: string,
   nodes: AST.Fragment["nodes"],
   filename: string,
   options: Options,
 ): string {
-
   const magicString = new MagicString(content);
 
-  function processNode(node: AST.Fragment["nodes"][number]) {
-    const isStorybookStory = node.type === "Component" && node.name === 'Story' && (filename.includes('.stories') || filename.includes('.story'))
-    if (node.type !== "Component" || (!options.elementNames.includes(node.name) && !isStorybookStory)) return;
+  function replaceStyleStrings(node: AST.Fragment["nodes"][number]) {
+
+    let newStyleString: string = '';
+    let styleAttribute: AST.Attribute | ExtendedProperty | null = null;
+
+    const isStorybookStory = node.type === "Component" &&
+      node.name === "Story" &&
+      (filename.includes(".stories") || filename.includes(".story"));
+
+    if (
+      node.type !== "Component" ||
+      (!options.elementNames.includes(node.name) && !isStorybookStory)
+    ) return;
 
     if (!isStorybookStory) {
-      const customStyling = node.attributes?.find(
-        (attr: AST.BaseElement["attributes"][number]) =>
-          "name" in attr && attr.name === options.attributeName,
-      );
-      if (customStyling) {
-        const styleString = convertsCsPropToInlineStyles(customStyling);
-        if (styleString) {
-          magicString.overwrite(
-            customStyling.start,
-            customStyling.end,
-            styleString,
-          );
-        }
-      }
+      ({ newStyleString, styleAttribute } = parseNode(node, options));
     } else {
-      const args = node.attributes?.find(
-        (attr: AST.BaseElement["attributes"][number]) =>
-          "name" in attr && attr.name === 'args',
+      ({ newStyleString, styleAttribute } = parseStorybookNode(node, options));
+    }
+
+    if (styleAttribute && styleAttribute.start && styleAttribute.end) {
+      magicString.overwrite(
+        styleAttribute.start,
+        styleAttribute.end,
+        newStyleString,
       );
-
-      if (!args || args.type !== 'Attribute' || typeof args.value === 'boolean' || Array.isArray(args.value) || args.value.expression.type !== 'ObjectExpression') return
-
-      const styleAttribute = args.value.expression.properties.find((property: Property | SpreadElement) => "key" in property && "name" in property.key && property.key.name === options.attributeName) as any
-      if (!styleAttribute || styleAttribute.type === 'SpreadElement' || !("properties" in styleAttribute.value)) return
-
-      const test = styleAttribute.value.properties as Property[]
-      // const customStyling = args?.properties.find(
-      //   (attr: AST.BaseElement["attributes"][number]) =>
-      //     "name" in attr && attr.name === options.attributeName,
-      // ) as any;
-
-
-      const styleString = `style: "${convertToSyleString(test).trim()}"`;
-      console.log(styleAttribute)
-      // const styleString = doesTheThing(customStyling.expression)
-      if (styleString) {
-        magicString.overwrite(
-          styleAttribute.start,
-          styleAttribute.end,
-          styleString,
-        );
-      }
     }
 
     if (Array.isArray(node.fragment?.nodes) && node.fragment.nodes.length > 0) {
-      node.fragment.nodes.forEach(processNode);
+      node.fragment.nodes.forEach(replaceStyleStrings);
     }
   }
-
-  nodes.forEach(processNode);
-
+  nodes.forEach(replaceStyleStrings);
   return magicString.toString();
 }
 
@@ -196,14 +206,10 @@ export function thread(
   filename: string,
   options: Options,
 ): string {
-
-  if (options.fileIdentifier && !filename.includes(options.fileIdentifier)) {
-    return content;
-  }
+  if (options.fileIdentifier && !filename.includes(options.fileIdentifier)) return content
   try {
     const ast = parse(content, { filename, modern: true });
-
-    return parseNodes(content, ast.fragment.nodes, filename, options);
+    return replaceFileContents(content, ast.fragment.nodes, filename, options);
   } catch (error) {
     console.error("Error parsing content", error);
     return content;


### PR DESCRIPTION
This adds support for parsing <Story args={{ cs: { \css properties\ } }} />

This additionally adds an option for whether it should try parsing storybook files or not (as this _should_ only be required for usage in Fabric or anyone else building their own design system library using this.

<sub><a href="https://huly.app/guest/lionwood?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI5OTkxZWU3Y2M1YTc4NTQyNzk3NzgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtbGlvbndvb2QtNjcyM2I0ZjEtNWMwM2NlOGY1Zi02YmUwZmMifQ.ZNPcKQ2aMxaNTBizDlJNJ3xhkFekq7dcBLarqdX3krA">Huly&reg;: <b>THRED-5</b></a></sub>