### PR TITLE
THRED-10: fix using a variable inside the style string

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopkeep/thread",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "exports": "./main.ts",
   "tasks": {
     "dev": "deno run --watch main.ts",

--- a/lib/thread.test.ts
+++ b/lib/thread.test.ts
@@ -8,6 +8,8 @@ const script = `<script lang="ts">
   let color = $state('aqua');
   let computedHeight = $state(200);
   let computedWidth = $derived(color === 'aqua' ? 200 : 100);
+  let asdf = 'background-color: green;';
+  let cs = { backgroundColor: 'purple' };
 </script>`;
 
 const style = `<style>
@@ -246,6 +248,18 @@ describe("parsing attributes", () => {
       `<Flexbox style="background-color: green; flex-flow: row;" cs={{ color: 'green' }}></Flexbox>`;
     const htmlOutput =
       `<Flexbox style="background-color: green; flex-flow: row; color: green;" ></Flexbox>`;
+    const input = script + htmlInput + style;
+    const output = script + htmlOutput + style;
+
+    const result = thread(input, "Test.svelte", options);
+    expect(result).toEqual(output);
+  });
+
+  it("combines existing style attribute when it is declared as a javascript variable", () => {
+    const htmlInput =
+      `<Flexbox {style} cs={{ color: 'green' }}></Flexbox>`;
+    const htmlOutput =
+      `<Flexbox style="{style} color: green;" ></Flexbox>`;
     const input = script + htmlInput + style;
     const output = script + htmlOutput + style;
 

--- a/lib/thread.test.ts
+++ b/lib/thread.test.ts
@@ -256,10 +256,8 @@ describe("parsing attributes", () => {
   });
 
   it("combines existing style attribute when it is declared as a javascript variable", () => {
-    const htmlInput =
-      `<Flexbox {style} cs={{ color: 'green' }}></Flexbox>`;
-    const htmlOutput =
-      `<Flexbox style="{style} color: green;" ></Flexbox>`;
+    const htmlInput = `<Flexbox {style} cs={{ color: 'green' }}></Flexbox>`;
+    const htmlOutput = `<Flexbox style="{style} color: green;" ></Flexbox>`;
     const input = script + htmlInput + style;
     const output = script + htmlOutput + style;
 

--- a/lib/thread.ts
+++ b/lib/thread.ts
@@ -55,8 +55,15 @@ function parseTemplateLiteralValue(value: any): string | null {
 }
 
 function getStyleString(styleAttribute: AST.Attribute): string {
-  if (typeof styleAttribute.value !== "boolean" && !Array.isArray(styleAttribute.value) && "name" in styleAttribute.value.expression) return `{${styleAttribute.value.expression.name}}`;
-  if (Array.isArray(styleAttribute.value) && styleAttribute.value[0].type === "Text") return styleAttribute.value[0].raw
+  if (
+    typeof styleAttribute.value !== "boolean" &&
+    !Array.isArray(styleAttribute.value) &&
+    "name" in styleAttribute.value.expression
+  ) return `{${styleAttribute.value.expression.name}}`;
+  if (
+    Array.isArray(styleAttribute.value) &&
+    styleAttribute.value[0].type === "Text"
+  ) return styleAttribute.value[0].raw;
   return "";
 }
 
@@ -103,13 +110,13 @@ function convertToSyleString(properties: Property[]): string {
           const leftValue = property.value.test.left.type === "Literal"
             ? property.value.test.left.raw
             : property.value.test.left.type === "Identifier"
-              ? property.value.test.left.name
-              : "";
+            ? property.value.test.left.name
+            : "";
           const rightValue = property.value.test.right.type === "Literal"
             ? property.value.test.right.raw
             : property.value.test.right.type === "Identifier"
-              ? property.value.test.right.name
-              : "";
+            ? property.value.test.right.name
+            : "";
           return acc +
             `${propertyName}: {${leftValue} ${property.value.test.operator} ${rightValue} ? '${property.value.consequent.value}' : '${property.value.alternate.value}'}; `;
         }
@@ -172,8 +179,9 @@ function parseStorybookNode(
     const filteredProperties = threadAttribute.value.properties.filter((
       property: Property | SpreadElement,
     ) => property.type === "Property");
-    const newStyleString = `style="${styleString + convertToSyleString(filteredProperties)
-      }"`;
+    const newStyleString = `style="${
+      styleString + convertToSyleString(filteredProperties)
+    }"`;
     return {
       newStyleString,
       start: styleAttribute.start,
@@ -186,8 +194,9 @@ function parseStorybookNode(
     const filteredProperties = threadAttribute.value.properties.filter((
       property: Property | SpreadElement,
     ) => property.type === "Property");
-    const newStyleString = `style: "${convertToSyleString(filteredProperties)
-      }"`;
+    const newStyleString = `style: "${
+      convertToSyleString(filteredProperties)
+    }"`;
     return {
       newStyleString,
       start: threadAttribute.start,
@@ -210,8 +219,9 @@ function parseNode(
 
   if (styleProperties && styleAttribute) {
     const styleString = getStyleString(styleAttribute);
-    const newStyleString = `style="${styleString + " " + convertToSyleString(styleProperties)
-      }"`;
+    const newStyleString = `style="${
+      styleString + " " + convertToSyleString(styleProperties)
+    }"`;
     return {
       newStyleString,
       start: styleAttribute.start,

--- a/lib/thread.ts
+++ b/lib/thread.ts
@@ -55,12 +55,8 @@ function parseTemplateLiteralValue(value: any): string | null {
 }
 
 function getStyleString(styleAttribute: AST.Attribute): string {
-  if (
-    Array.isArray(styleAttribute.value) &&
-    styleAttribute.value[0].type === "Text"
-  ) {
-    return styleAttribute.value[0].raw;
-  }
+  if (typeof styleAttribute.value !== "boolean" && !Array.isArray(styleAttribute.value) && "name" in styleAttribute.value.expression) return `{${styleAttribute.value.expression.name}}`;
+  if (Array.isArray(styleAttribute.value) && styleAttribute.value[0].type === "Text") return styleAttribute.value[0].raw
   return "";
 }
 
@@ -107,13 +103,13 @@ function convertToSyleString(properties: Property[]): string {
           const leftValue = property.value.test.left.type === "Literal"
             ? property.value.test.left.raw
             : property.value.test.left.type === "Identifier"
-            ? property.value.test.left.name
-            : "";
+              ? property.value.test.left.name
+              : "";
           const rightValue = property.value.test.right.type === "Literal"
             ? property.value.test.right.raw
             : property.value.test.right.type === "Identifier"
-            ? property.value.test.right.name
-            : "";
+              ? property.value.test.right.name
+              : "";
           return acc +
             `${propertyName}: {${leftValue} ${property.value.test.operator} ${rightValue} ? '${property.value.consequent.value}' : '${property.value.alternate.value}'}; `;
         }
@@ -176,9 +172,8 @@ function parseStorybookNode(
     const filteredProperties = threadAttribute.value.properties.filter((
       property: Property | SpreadElement,
     ) => property.type === "Property");
-    const newStyleString = `style="${
-      styleString + convertToSyleString(filteredProperties)
-    }"`;
+    const newStyleString = `style="${styleString + convertToSyleString(filteredProperties)
+      }"`;
     return {
       newStyleString,
       start: styleAttribute.start,
@@ -191,9 +186,8 @@ function parseStorybookNode(
     const filteredProperties = threadAttribute.value.properties.filter((
       property: Property | SpreadElement,
     ) => property.type === "Property");
-    const newStyleString = `style: "${
-      convertToSyleString(filteredProperties)
-    }"`;
+    const newStyleString = `style: "${convertToSyleString(filteredProperties)
+      }"`;
     return {
       newStyleString,
       start: threadAttribute.start,
@@ -216,9 +210,8 @@ function parseNode(
 
   if (styleProperties && styleAttribute) {
     const styleString = getStyleString(styleAttribute);
-    const newStyleString = `style="${
-      styleString + " " + convertToSyleString(styleProperties)
-    }"`;
+    const newStyleString = `style="${styleString + " " + convertToSyleString(styleProperties)
+      }"`;
     return {
       newStyleString,
       start: styleAttribute.start,
@@ -262,10 +255,9 @@ function replaceFileContents(
     }
 
     if (result.kill) {
-      magicString.overwrite(
+      magicString.remove(
         result.kill.start,
         result.kill.end,
-        "",
       );
     }
 


### PR DESCRIPTION
Fixes the getStyleString function to return name if the style string is a variable

<sub><a href="https://huly.app/guest/lionwood?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJlNDA0Y2U3Y2M1YTc4NTQyOThmMGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtbGlvbndvb2QtNjcyM2I0ZjEtNWMwM2NlOGY1Zi02YmUwZmMifQ.y3wq4haxQ3_gmxMhUNpZ3N2NxCq1i9bZWSqyCEwlurM">Huly&reg;: <b>THRED-11</b></a></sub>