### PR TITLE
THRED-12: allows for css variables as key

### DIFF
--- a/lib/thread.test.ts
+++ b/lib/thread.test.ts
@@ -163,6 +163,16 @@ describe("parsing attributes", () => {
     expect(result).toEqual(output);
   });
 
+  it("converts a single attribute that is a css variable", () => {
+    const htmlInput = `<Flexbox cs={{ '--gap': '10px' }}></Flexbox>`;
+    const htmlOutput = `<Flexbox style="--gap: 10px;"></Flexbox>`;
+    const input = script + htmlInput + style;
+    const output = script + htmlOutput + style;
+
+    const result = thread(input, "Test.svelte", options);
+    expect(result).toEqual(output);
+  });
+
   it("converts multiple attributes", () => {
     const htmlInput =
       `<Flexbox cs={{ gap: '10px', backgroundColor: 'aqua' }}></Flexbox>`;

--- a/lib/thread.ts
+++ b/lib/thread.ts
@@ -73,9 +73,14 @@ function convertToSyleString(properties: Property[]): string {
     (acc: string, property: Property | SpreadElement) => {
       // TODO - this is also a mess
       if (!("key" in property)) return acc;
-      if (!("name" in property.key)) return acc;
 
-      const propertyName = camelToKebabCase(property.key.name);
+      let propertyName;
+      if ("name" in property.key) {
+        propertyName = camelToKebabCase(property.key.name);
+      }
+      // Allows for css variables - i.e. cs={{'--gap': 10px}}
+      if ("value" in property.key) propertyName = property.key.value;
+      if (!propertyName) return acc;
 
       // Returns if the value is a variable - i.e. cs={{gap: gapAmount}}
       if ("name" in property.value) {


### PR DESCRIPTION
Fixes issue #11 by allowing value properties that begin with "--"

<sub><a href="https://huly.app/guest/lionwood?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMwNmRiNGU3Y2M1YTc4NTQyYTVhYjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtbGlvbndvb2QtNjcyM2I0ZjEtNWMwM2NlOGY1Zi02YmUwZmMifQ.19z1BZyEOxY4TbjyVGBstGKgzTqIBX5P2mXZO87acsA">Huly&reg;: <b>THRED-13</b></a></sub>