### PR TITLE
version bump

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopkeep/thread",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "exports": "./main.ts",
   "tasks": {
     "dev": "deno run --watch main.ts",


### PR DESCRIPTION
After my github actions updates where I was forcing failures I now need to actually update the version number to get jsr inline with github

<sub><a href="https://huly.app/guest/lionwood?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMwZjA4NWU3Y2M1YTc4NTQyYTY1NGIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtbGlvbndvb2QtNjcyM2I0ZjEtNWMwM2NlOGY1Zi02YmUwZmMifQ.ehydJSarvbU-y9t7VLyR6Wc_sCgg0o3Kr3xeqkvi0_M">Huly&reg;: <b>THRED-22</b></a></sub>