### PR TITLE
New action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,12 @@
 name: Build
 
-on: push
-
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       id-token: write # The OIDC ID token is used for authentication with JSR.

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      id-token: write # The OIDC ID token is used for authentication with JSR.
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          output=$(npx jsr publish --dry-run 2>&1)
+          echo "$output"
+          if echo "$output" | grep -q 'Skipping, already published'; then
+            echo "::error::The publish step failed because this version number has already been published."
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,9 @@ name: Publish
 on:
   workflow_run:
     workflows: ["Build"]
+    branches: ["main"] # Only trigger if the Build workflow ran on main
     types:
       - completed
-  push:
-    branches:
-      - main
 
 jobs:
   publish:


### PR DESCRIPTION
Some new actions requirements.

Build should only run when a PR is opened or a new push on main.

And there is now a PR step for a dry run for publish to try and catch version number issues early.

<sub><a href="https://huly.app/guest/lionwood?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMwZjJjNmU3Y2M1YTc4NTQyYTY1OTQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtbGlvbndvb2QtNjcyM2I0ZjEtNWMwM2NlOGY1Zi02YmUwZmMifQ.lppTUvWFbiznL5pndKvYQG-s0sPvyQKrudzFjFLmQTI">Huly&reg;: <b>THRED-23</b></a></sub>