### PR TITLE
THRED-6: rename storybook file options as private

### DIFF
--- a/lib/thread.test.ts
+++ b/lib/thread.test.ts
@@ -93,7 +93,10 @@ describe("tests storybook files", () => {
   const htmlOutput =
     `<Story name="Primary" args={{ style: "background-color: aqua; width: 50px; height: 50px;", text: 'Hello, world!'}}/>`;
 
-  const storybookOptions = { ...options, shouldIncludeStorybookFiles: true };
+  const storybookOptions = {
+    ...options,
+    _internalShouldIncludeStorybookFiles: true,
+  };
 
   it("works if file has .story file extension", () => {
     const input = script + htmlInput + style;
@@ -141,7 +144,7 @@ describe("tests storybook files", () => {
     });
     expect(result).toEqual(output);
   });
-  it("does not parse if shouldIncludeStorybookOptions is not set", () => {
+  it("does not parse if  _internalShouldIncludeStorybookFiles Options is not set", () => {
     const input = script + htmlInput + htmlInput + style;
 
     const result = thread(input, "Test.thread.story.svelte", {

--- a/lib/thread.ts
+++ b/lib/thread.ts
@@ -15,7 +15,7 @@ export type Options = {
   fileIdentifier?: string;
   attributeName: string;
   elementNames: string[];
-  shouldIncludeStorybookFiles?: boolean;
+  _internalShouldIncludeStorybookFiles?: boolean;
 };
 
 type Position = {
@@ -298,7 +298,7 @@ function replaceFileContents(
 
     if (!isStorybookStory) {
       result = parseNode(node, options);
-    } else if (options.shouldIncludeStorybookFiles) {
+    } else if (options._internalShouldIncludeStorybookFiles) {
       result = parseStorybookNode(node, options);
     }
 


### PR DESCRIPTION
Renames storybook option to indicate its private and should not be used for public consumption

<sub><a href="https://huly.app/guest/lionwood?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRkNmFiMmQyZWY0Y2JjYzQ2ZDU1MDUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtbGlvbndvb2QtNjcyM2I0ZjEtNWMwM2NlOGY1Zi02YmUwZmMifQ.-IwNqE05tWHf3pTPlkWmwpqZZ7woMokD4yrnalqXn6k">Huly&reg;: <b>THRED-32</b></a></sub>